### PR TITLE
Removed Regular Expression parsing for a more robust approach

### DIFF
--- a/ConsoleArgs/ConsoleArgs.csproj
+++ b/ConsoleArgs/ConsoleArgs.csproj
@@ -1,14 +1,14 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AssemblyVersion>1.0.0.2</AssemblyVersion>
     <FileVersion>1.0.0.2</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="..\..\..\..\Documents\GitHub\XML-To-Data-Class\XMLToDataClass\CommandSettings.cs" Link="CommandSettings.cs" />
+    <Compile Include="..\..\XML-To-Data-Class\XMLToDataClass\CommandSettings.cs" Link="CommandSettings.cs" />
   </ItemGroup>
 
 </Project>

--- a/ConsoleArgsCoreTests/ConsoleArgsCoreTests.csproj
+++ b/ConsoleArgsCoreTests/ConsoleArgsCoreTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
 
@@ -11,9 +11,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.3.2" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.3.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.2.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.2.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This solved an issue where Windows and Linux handle quotes differently so values with spaces no longer have to be in quotes. Also made it so '_' can be used in signed integer values.